### PR TITLE
Solaredge enhancements

### DIFF
--- a/samples/solaredge.md
+++ b/samples/solaredge.md
@@ -25,23 +25,35 @@ mec_meter_emulator:
       {{
         (states('sensor.solaredge_i1_m1_ac_power') | float(default=0) * -1 )
       }}
+
     # Power consumption of the house: Negative = consumption, positive = invalid
     ld: >
       {{
         (states('sensor.solaredge_i1_m1_ac_power') | float(default=0)) +
-        (states('sensor.solaredge_i1_ac_power') | float(default=0) * -1 )
+        (states('sensor.solaredge_i1_ac_power') | float(default=0) * -1 ) +
+        min(
+          (states('sensor.solaredge_i1_dc_power') | float(default=0)) +
+          (states('sensor.solaredge_i1_b1_dc_power') | float(default=0)),
+          0
+        )
       }}
+
     # Current PV generation power: Positive = production, negative = invalid
     pv: >
       {{
-        (states('sensor.solaredge_i1_dc_power') | float(default=0)) +
-        (states('sensor.solaredge_i1_b1_dc_power') | float(default=0))
+        max(
+          (states('sensor.solaredge_i1_dc_power') | float(default=0)) +
+          (states('sensor.solaredge_i1_b1_dc_power') | float(default=0)),
+          0
+        )
       }}
+
     # current battery input / output power: positive: battery discharging, negative: battery charging
     akk: >
       {{
         (states('sensor.solaredge_i1_b1_dc_power') | float(default=0) * -1 )
       }}
+
     # SOC of the Home Battery, 0-100
     soc: >
       {{

--- a/samples/solaredge.md
+++ b/samples/solaredge.md
@@ -53,6 +53,6 @@ The five values are all optional, depending on the inverter hardware and availab
 
 ## Remarks
 
-The above sample assumes that besides the inverter an energy meter, eighter separate or bundles with a backup interface is installed, it's power value is accessed with `(states('sensor.solaredge_i1_m1_ac_power')`. 
+The above sample assumes that besides the inverter an energy meter, eighter separate or bundles with a backup interface is installed, it's power value is accessed with `(states('sensor.solaredge_i1_m1_ac_power')`.
 
 In case no battery is installed, simple remove all `(states('sensor.solaredge_i1_b1_dc_power')` references.


### PR DESCRIPTION
Refine calculation of `pv` and `ld`.

`pv` is lower bounded to zero, to avoid negative production of inverter in case of standby or battery loading

`ld` is increased by inverter self-consumption in the case described above